### PR TITLE
Fix/transformation graph

### DIFF
--- a/tasks/transformation-graph/Experiment.ipynb
+++ b/tasks/transformation-graph/Experiment.ipynb
@@ -33,7 +33,7 @@
     "# parâmetros\n",
     "dataset = \"/tmp/data/hotel_bookings.csv\" #@param {type:\"string\"}\n",
     "target = \"is_canceled\" #@param {type:\"feature\", label:\"Atributo alvo\", description:\"Esse valor será utilizado para garantir que o alvo não seja removido.\"}\n",
-    "date = \"reservation_status_date\" #@param {type:\"feature\", label:\"Coluna de data\", description:\"Coluna com data que será utilizada para extrair novas características.\"}\n",
+    "date = None #@param {type:\"feature\", label:\"Coluna de data\", description:\"Coluna com data que será utilizada para extrair novas características.\"}\n",
     "group = [\"hotel\"] #@param {type:\"feature\", multiple:true, label:\"Colunas para agrupar\", description:\"Colunas que serão utilizadas para agrupar e extrair novas características.\"}\n",
     "\n",
     "budget = 20 #@param {type:\"integer\", label:\"Limite de busca\", description:\"Parâmetro para aumentar ou diminuir a busca por soluções de acordo com as restrições de recursos computacionais.\"}"


### PR DESCRIPTION
Quando não se passava a coluna de datas o código pegava um valor padrão(setado no input) ao invés de pegar o valor none que não é passado, isso acarretava em erros pois no código está previsto que se vier vazia esteja como none a variável.