### PR TITLE
feature: Limite de quantas colunas aparece na comparação entre antes …

### DIFF
--- a/tasks/robust-scaler/Experiment.ipynb
+++ b/tasks/robust-scaler/Experiment.ipynb
@@ -257,7 +257,7 @@
     "    new_sample = df[columns[numerical_indexes]].iloc[number-1:number].values.tolist()[0]\n",
     "    old_sample = pd.read_csv(dataset)[columns[numerical_indexes]].iloc[number-1:number].values.tolist()[0]\n",
     "    \n",
-    "    for i in range(len(columns[numerical_indexes])):\n",
+    "    for i in range(len(columns[numerical_indexes][:10])):\n",
     "        new_df.loc[len(new_df)] = [columns[numerical_indexes][i], old_sample[i], new_sample[i], featuretypes[numerical_indexes][i]]\n",
     "    \n",
     "    return new_df\n",


### PR DESCRIPTION
Coloquei um limite para a quantidade de colunas para que a comparação entre o antes e depois da componente fique bem visualmente, pois não é preciso mostrar todas as colunas númericas.